### PR TITLE
feat(handler): supporting handlers with different number of params

### DIFF
--- a/epsagon/src/main/java/com/epsagon/events/MetadataBuilder.java
+++ b/epsagon/src/main/java/com/epsagon/events/MetadataBuilder.java
@@ -46,7 +46,7 @@ public class MetadataBuilder {
      */
     public MetadataBuilder putIfAllData(String key, String value) {
         if (!EpsagonConfig.getInstance().isMetadataOnly()) {
-            _metadata.put(key, value);
+            put(key, value);
         }
         return this;
     }

--- a/epsagon/src/main/java/com/epsagon/events/triggers/TriggerFactory.java
+++ b/epsagon/src/main/java/com/epsagon/events/triggers/TriggerFactory.java
@@ -51,6 +51,9 @@ public class TriggerFactory {
             Object event,
             Context context
     ) {
+        if (event == null) {
+            return JSONTrigger.newBuilder(null, context);
+        }
         return TRIGGERS_BY_EVENT.getOrDefault(
                 event.getClass(),
                 (e) -> JSONTrigger.newBuilder(e, context)

--- a/epsagon/src/main/java/com/epsagon/executors/Executor.java
+++ b/epsagon/src/main/java/com/epsagon/executors/Executor.java
@@ -3,6 +3,7 @@ package com.epsagon.executors;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import com.epsagon.Trace;
 
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -13,9 +14,10 @@ import java.lang.reflect.Method;
  * A class representing a client's handler executor.
  */
 public abstract class Executor {
-    protected static Class<?> _userHandlerClass;
-    protected static Object _userHandlerObj;
-    protected static Method _userHandlerMethod;
+    protected Class<?> _userHandlerClass;
+    protected Object _userHandlerObj;
+    protected Method _userHandlerMethod;
+    protected Trace _trace = Trace.getInstance();
 
     /**
      * @param userHandlerClass The class of the user handler.

--- a/epsagon/src/main/java/com/epsagon/executors/POJOExecutor.java
+++ b/epsagon/src/main/java/com/epsagon/executors/POJOExecutor.java
@@ -1,12 +1,21 @@
 package com.epsagon.executors;
 
 import com.amazonaws.services.lambda.runtime.Context;
+import com.epsagon.TimeHelper;
+import com.epsagon.events.EventBuildHelper;
+import com.epsagon.events.runners.LambdaRunner;
+import com.epsagon.protocol.EventOuterClass;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 /**
  * An executor for client request that don't implement an AWS interface, POJO requests.
  */
 public class POJOExecutor extends BasePOJOExecutor {
+
     /**
      * @param userHandlerClass The class of the user handler.
      * @param handlerName The name of the method for the user handler.
@@ -36,12 +45,52 @@ public class POJOExecutor extends BasePOJOExecutor {
 
         if (candidate == null) {
             throw new ExecutorException(
-                    "No appropriate function with the name " +
-                            handlerName +
-                            " was found in " +
-                            userHandlerClass.getCanonicalName()
+                "No appropriate function with the name " +
+                        handlerName +
+                        " was found in " +
+                        userHandlerClass.getCanonicalName()
             );
         }
         _userHandlerMethod = candidate;
+    }
+
+    public void execute(InputStream input, OutputStream output, Context context) throws Throwable {
+        EventOuterClass.Event.Builder runnerBuilder = LambdaRunner.newBuilder(context);
+        runnerBuilder.setStartTime(TimeHelper.getCurrentTime());
+
+        try {
+            Object realInput = parseInput(input, context);
+            Object result = null;
+            switch (_userHandlerMethod.getParameterCount()) {
+                case 0:
+                    // no parameters
+                    result = _userHandlerMethod.invoke(_userHandlerObj);
+                    break;
+                case 1:
+                    // only context or event
+                    if (_userHandlerMethod.getParameterTypes()[0] == Context.class) {
+                        result = _userHandlerMethod.invoke(_userHandlerObj, context);
+                    } else {
+                        result = _userHandlerMethod.invoke(_userHandlerObj, realInput);
+                    }
+                    break;
+                case 2:
+                    // both event and context
+                    result = _userHandlerMethod.invoke(_userHandlerObj, realInput, context);
+                    break;
+            }
+
+            handleResult(output, runnerBuilder, result);
+
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            _trace.addException(e);
+            throw e;
+        } catch (Throwable e) {
+            EventBuildHelper.setException(runnerBuilder, e);
+            throw e;
+        } finally {
+            _trace.addEvent(EventBuildHelper.setDuration(runnerBuilder));
+        }
+
     }
 }


### PR DESCRIPTION
Supporting these cases:
```
returnType handler() {}
returnType handler(inputType input) {}
returnType handler(inputType input) {}
returnType handler(inputType input, Context context) {}
```
support for requestHandler interface remains untouched.

also fixed a minor bug with `MetadataBuilder`